### PR TITLE
TICKET-001: fix: update IntelliJ platform version to stable 2024.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,24 +1,26 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = com.github.jonajor.ticketcommitguard
-pluginName = ticket-commit-guard
+pluginName = Ticket Commit Guard
 pluginRepositoryUrl = https://github.com/Jonajor/ticket-commit-guard
 # SemVer format -> https://semver.org
 pluginVersion = 0.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 243
+pluginSinceBuild = 242
+pluginUntilBuild = 244.*
 
-# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
+# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
 platformType = IC
-platformVersion = 2024.3.6
+# Use a stable, tested version instead of 2024.3.6
+platformVersion = 2024.3.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
+# Example: platformPlugins = com.jetbrains.php:203.4449.22
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = Git4Idea
-# Example: platformBundledModules = intellij.spellchecker
+# Example: platformBundledModules = com.intellij.modules.remote-run
 platformBundledModules =
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
@@ -32,3 +34,6 @@ org.gradle.configuration-cache = true
 
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
+
+# Enable Gradle Parallel Builds -> https://docs.gradle.org/current/userguide/performance.html#parallel_execution
+org.gradle.parallel = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.4.0"
-intelliJPlatform = "2.7.1"
+intelliJPlatform = "2.9.0"
 kotlin = "2.2.0"
 kover = "0.9.1"
 qodana = "2025.1.1"


### PR DESCRIPTION
- Replace problematic 2024.3.6 with working 2024.3.1
- Resolves CI build failures due to missing IDE artifacts
- Maintains compatibility range 2024.2 through 2024.4