### PR TITLE
TICKET-001: fix: align IDE verification and EDT handling in CommitPan…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,7 +130,10 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            recommended()
+            create(
+                providers.gradleProperty("platformType"),     // e.g. "IC"
+                providers.gradleProperty("platformVersion")   // e.g. "2024.3.1"
+            )
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ pluginGroup = com.github.jonajor.ticketcommitguard
 pluginName = Ticket Commit Guard
 pluginRepositoryUrl = https://github.com/Jonajor/ticket-commit-guard
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.2
+pluginVersion = 0.0.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 242
-pluginUntilBuild = 244.*
+pluginSinceBuild = 243
+pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
 platformType = IC

--- a/src/main/kotlin/com/github/jonajor/ticketcommitguard/CommitPanelHolder.kt
+++ b/src/main/kotlin/com/github/jonajor/ticketcommitguard/CommitPanelHolder.kt
@@ -1,11 +1,14 @@
 package com.github.jonajor.ticketcommitguard
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.CheckinProjectPanel
 import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentHashMap
 
 object CommitPanelHolder {
+    private val log = Logger.getInstance(CommitPanelHolder::class.java)
     private val panels = ConcurrentHashMap<Project, WeakReference<CheckinProjectPanel>>()
 
     fun setPanel(project: Project, panel: CheckinProjectPanel) {
@@ -13,10 +16,16 @@ object CommitPanelHolder {
     }
 
     fun clearMessageIfPresent(project: Project) {
-        panels[project]?.get()?.commitMessage = ""
-    }
-
-    fun drop(project: Project) {
-        panels.remove(project)
+        if (project.isDisposed) return
+        ApplicationManager.getApplication().invokeLater({
+            if (project.isDisposed) return@invokeLater
+            val panel = panels[project]?.get() ?: return@invokeLater
+            try {
+                // EditorTextField/CommitMessage handles write-intent internally
+                panel.commitMessage = ""
+            } catch (t: Throwable) {
+                log.warn("ticket-commit-guard: failed to clear commit message on EDT", t)
+            }
+        }, project.disposed)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <id>com.jonathan.ticketguard.commitprefix</id>
     <name>Ticket Commit Guard</name>
     <vendor email="jonathanaugjorge@gmail.com" url="https://github.com/Jonajor">Jonathan Jorge</vendor>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
 
     <description><![CDATA[
       <p>
@@ -51,8 +51,8 @@
       </p>
     ]]></description>
 
-    <!-- 2024.2 (242) up to but not including 2024.4 -->
-    <idea-version since-build="242" until-build="243.*"/>
+    <!-- 2024.2 (243) up to but not including 2024.4 -->
+    <idea-version since-build="243" until-build="243.*"/>
 
     <depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>


### PR DESCRIPTION
…elHolder

- Updated CommitPanelHolder to clear commit message on EDT via invokeLater and removed unnecessary WriteIntentReadAction to avoid experimental API warnings
- Added disposal checks and safer WeakReference lookup
- Fixed build.gradle.kts to use new pluginVerification { ides { create(...) } } API and pinned verification to IC-2024.3.1 (avoids missing 253.* artifacts)
- Synced pluginSinceBuild/untilBuild with 243 to match platformVersion